### PR TITLE
Add Claude provider and OLLAMA_URL configuration

### DIFF
--- a/CONFIG_YAML_REFERENCE.md
+++ b/CONFIG_YAML_REFERENCE.md
@@ -232,9 +232,10 @@ identical agents.
 |-----|------|----------|---------|-------------|
 | `id` | string | Yes | — | Unique base identifier. Must be unique across all actor entries. Replica IDs are `<id>_1`, `<id>_2`, … |
 | `replicas` | integer | No | `1` | Number of identical agents to create from this definition. |
-| `provider` | string | No | `ollama` | LLM provider: `ollama` \| `openai` \| `google` \| `grok`. |
+| `provider` | string | No | `ollama` | LLM provider: `ollama` \| `claude` \| `openai` \| `google` \| `grok`. |
 | `model_name` (or `model`) | string | No | `llama3.1:8b` | Model name. For Google: `gemini-2.5-pro`, etc. |
-| `api_key` | string | No | `""` | Provider API key. If omitted, the engine looks for `OPENAI_API_KEY` / `GOOGLE_API_KEY` / `GROK_API_KEY` in env vars and then the `.env` file. |
+| `api_key` | string | No | `""` | Provider API key. If omitted, the engine looks for `OPENAI_API_KEY` / `GOOGLE_API_KEY` / `GROK_API_KEY` / `ANTHROPIC_API_KEY` /  in env vars and then the `.env` file. |
+| `OLLAMA_URL` *(env var)* | string | No | `http://localhost:11434` | Base URL for the Ollama server. Set this env var to point agents at a remote or non-default Ollama instance. The `/v1` path is appended automatically. |  
 | `base_url` | string | No | provider default | Custom endpoint URL. Useful for self-hosted models or proxies. |
 | `temperature` | number | No | `0.1` | Direct LLM temperature control in `[0, 2]`. Lower values make the agent more deterministic; higher values make it more exploratory and erratic. |
 | `irrationality` | number | No | unset | High-level behavior knob in `[0, 1]`. Mapped internally to temperature `[0.1, 1.3]`. Use this when you want to express how "irrational" an agent should be without thinking in provider-specific temperature terms. If both are present, `temperature` wins. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ emerges from the decisions of heterogeneous, bounded-rational agents.
 
     ---
 
-    OpenAI, Gemini, Grok, or Ollama. Each agent has a persona, hard constraints,
+    OpenAI, Gemini, Grok, Claude or Ollama. Each agent has a persona, hard constraints,
     tool access, and persistent RAG memory across epochs.
 
 - :material-chart-candlestick: **Market Microstructure**
@@ -86,7 +86,10 @@ cp .env.example .env        # (1) add at least one provider key
 docker compose up --build   # (2) backend :5000 · frontend :3000
 ```
 
-1. Supported keys: `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROK_API_KEY`. Leave unused keys blank. For a fully local setup use Ollama — no key required.
+1.   Supported keys: `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROK_API_KEY`,
+  `ANTHROPIC_API_KEY`. Leave unused keys blank. For a fully local setup use
+  Ollama, no key required; set `OLLAMA_URL` if your Ollama server is not at    
+  `http://localhost:11434`.
 
 See [Quick Start](quickstart.md) for local dev, Ollama-only, and bare-metal instructions.
 

--- a/server/engine/agents/DoxaAgent.py
+++ b/server/engine/agents/DoxaAgent.py
@@ -176,6 +176,16 @@ class DoxaAgent(autogen.ConversableAgent):
                 "temperature": temperature,
             }
         
+        elif provider == 'claude':
+            llm_config = {
+                "config_list":[{
+                    "model": model or "claude-sonnet-4-6",
+                    "api_type": "anthropic",
+                    "api_key": config.get('api_key',
+                    os.environ.get('ANTHROPIC_API_KEY', '')),
+                    }],
+                    "temperature": temperature
+            }
         elif provider == 'grok':
             llm_config = {
                 "config_list": [{
@@ -190,7 +200,7 @@ class DoxaAgent(autogen.ConversableAgent):
             llm_config = {
                 "config_list": [{
                     "model": model,
-                    "base_url": "http://localhost:11434/v1",
+                    "base_url": os.environ.get('OLLAMA_BASE_URL', 'http://localhost:11434') + f"/v1",
                     "api_type": "openai",
                     "api_key": "ollama",
                     "price": [0,0]


### PR DESCRIPTION
Closes #1, closes #2.

  ## What changed                                                               
   
  - **Claude provider** (`provider: claude`) added to `DoxaAgent` — uses        
  `api_type: anthropic` and reads `ANTHROPIC_API_KEY` from the env. The chatbot
  (`DoxaChatbot`) remains Ollama-only as per current design.                    
  - **OLLAMA_URL** — the Ollama `base_url` in `DoxaAgent` is now read from the
  `OLLAMA_BASE_URL` env var (falls back to `http://localhost:11434`), so users  
  running a remote Ollama instance no longer need to patch the code.
  - Docs updated in `CONFIG_YAML_REFERENCE.md` and `docs/index.md` to reflect   
  both additions. 