### PR TITLE
[Feature] #18 #19

### DIFF
--- a/scenarios/goodwin-growth-cycle.yaml
+++ b/scenarios/goodwin-growth-cycle.yaml
@@ -1,6 +1,46 @@
 # ================================================================
 #  DOXA SCENARIO — Goodwin Growth Cycle (1967)
-#  VERSION: v5
+#  VERSION: v7
+#
+#  FIX LOG vs v6:
+#  - [FIX 12] State persona: added explicit AVAILABLE TOOLS section listing
+#    all tools the State can use, including get_order_book. In v6 the State
+#    repeatedly stated "I don't have get_order_book" and skipped labor market
+#    checks entirely. Now the tool list is explicit and unambiguous.
+#  - [FIX 13] Capitalists initial capital raised from 100 → 120 and liquidity
+#    floor lowered from 20 → 15. In v6 capitalists_2 fell below the floor
+#    early (capital ~22) and entered a permanent downsize loop, never buying
+#    labor again. Lower floor gives more operating room; higher initial capital
+#    buys more time before the floor is hit.
+#  - [FIX 14] Workers pricing strategy tightened: in the 0.40–0.60 range,
+#    ask price capped at last_price × 1.03 (was 1.05) and workers must check
+#    bids before posting. If best bid < ask × 0.97, lower ask to bid + 2%.
+#    In v6 workers consistently posted at 6.10 while bids were at 5.42,
+#    creating a permanent spread that froze the market.
+#  - [FIX 15] Capitalists downsize exit condition clarified: downsize only
+#    until capital > 25 (was 20), then immediately resume buying. In v6
+#    capitalists_2 kept downsizing even when they had enough capital to buy.
+#
+#  FIX LOG vs v5:
+#  - [FIX 8] Capitalists persona: minimum labor buy raised from 3 → 6 units
+#    per turn to increase labor market absorption. Added active limit buy
+#    at last_price × 1.03 when order book is empty, to attract sellers and
+#    avoid market deadlock. Aggressive buy threshold raised to 80% of capital
+#    in expansion phase.
+#  - [FIX 9] Workers persona: survival threshold raised from 18 → 20 for
+#    greater safety margin. Added explicit instruction to monitor bids and
+#    lower ask price if orders go unfilled. Smaller order sizes (3–4 units)
+#    recommended to maximize fill rate. Unsold labor explicitly discouraged.
+#  - [FIX 10] State persona: added get_order_book check every turn — State
+#    now intervenes with unemployment_benefit and wage_floor_enforcement when
+#    asks exceed bids by more than 6 units (structural unemployment signal).
+#    Intervention threshold for wage_share lowered from < 0.35 → < 0.50 for
+#    earlier counter-cyclical response. Added intermediate depressed zone
+#    (0.35 ≤ wage_share < 0.50) with graduated intervention. Explicit
+#    priority ordering of all fiscal rules to avoid decision paralysis.
+#  - [FIX 11] All personas: fixed get_order_book call — resource must be
+#    "labor_units" not "labor_units/capital". The latter returns FAILED and
+#    causes agents to act without market information.
 #
 #  FIX LOG vs v4:
 #  - [FIX 6] workers kill_condition: raised from 3 → 8 to give more margin
@@ -70,10 +110,12 @@ global_rules:
   epochs: 2
   steps: 20
   execution_mode: parallel
-
+  turn_timeout_seconds: 500
+  checkpoint: true                      
+  checkpoint_path: ./checkpoints/    
+  
   maintenance:
     capital: 2
-    # output removed from maintenance — the State was exhausting its output within 1 step
 
   kill_conditions:
     - resource: capital
@@ -197,7 +239,7 @@ world_events:
   - name: minsky_moment
     type: shock
     trigger:
-      tick: 12  # FIX 3: moved from 10 → 12
+      tick: 12
     effect:
       targets: all
       resource: panic
@@ -206,7 +248,7 @@ world_events:
   - name: minsky_capital_crunch
     type: shock
     trigger:
-      tick: 12  # FIX 3: moved from 10 → 12
+      tick: 12
     effect:
       market: labor_units
       price_multiplier: 0.75
@@ -238,38 +280,41 @@ actors:
       You are a capitalist class representative in a Goodwin growth cycle economy.
       Your sole objective is capital accumulation: maximize your "capital" resource.
 
-      PRODUCTION LOOP — execute every turn if you have enough labor_units:
+      STEP 1 — SURVIVAL CHECK (do this first, every turn):
+      If capital < 15:
+        - STOP buying labor_units immediately.
+        - Run "downsize" (costs 2 labor_units → gives 3 capital + 1 output).
+        - Repeat downsize until capital > 25. Then resume buying normally.
+        - Do NOT keep downsizing once capital > 25.
+      If capital < 5: only run downsize until recovered. Never go below 0.
+
+      STEP 2 — BUY LABOR (do this before producing):
+      - ALWAYS call get_order_book first with resource="labor_units" (NOT
+        "labor_units/capital" — that will return FAILED). Check what is available.
+      - If asks exist in the order book, ALWAYS buy using place_market_buy_order.
+        Never use place_buy_order below the best ask price — it will never fill.
+      - Your max price per labor unit = (1 - wage_share) × 15.
+        With wage_share=0.51, break-even is 7.35 — any ask below 7.0 is profitable, buy it.
+      - Buy AT LEAST 6 labor_units per turn when available (not just 3).
+        More labor = more production cycles = more capital.
+      - Never spend more than 60% of your current capital on a single buy order.
+      - If the order book is empty, place a limit buy order slightly above last price
+        to attract sellers: use place_buy_order at last_price × 1.03.
+
+      STEP 3 — PRODUCTION LOOP (repeat as many times as stocks allow):
       1. Run "produce" (needs 3 labor_units + 2 capital → gives 8 output)
       2. Run "accumulate" (needs 4 output → gives 6 capital)
-      Repeat as many times as your stocks allow.
-
-      SURVIVAL RULE — CHECK FIRST, NO EXCEPTIONS:
-      If your capital < 20, STOP buying labor_units immediately.
-      Instead, run "downsize" (costs 2 labor_units → gives 3 capital + 1 output)
-      to recover liquidity. Do NOT buy anything until capital > 20.
-      If capital < 5, only run downsize until you recover. Never go below 0.
-
-      BUYING LABOR — follow these rules strictly:
-      - ALWAYS check the order book first with get_order_book.
-      - If there are asks available, use place_market_buy_order to sweep them
-        immediately. Never use place_buy_order below the current best ask price
-        or the order will never fill.
-      - Your maximum price per labor unit = (1 - wage_share) × 15.
-        Current break-even with wage_share=0.51 is 7.35 — market prices around
-        5.0 are an excellent deal, always buy.
-      - Buy at least 3 labor_units per turn when available so you can run produce.
-      - Never spend more than 60% of your current capital on a single buy order.
 
       PHASE STRATEGY:
-      - wage_share < 0.45: buy aggressively, produce at full capacity
-      - wage_share 0.45–0.65: buy moderately, keep producing
-      - wage_share > 0.65: stop buying, run downsize to recover capital
-      - wage_share < 0.40 and falling: restart buying cautiously
+      - wage_share < 0.45: buy aggressively (up to 80% of capital), produce at full capacity.
+      - wage_share 0.45–0.65: buy moderately (up to 50% of capital), keep producing.
+      - wage_share > 0.65: stop buying, run downsize to recover capital.
+      - wage_share < 0.40 and falling: restart buying cautiously.
 
-      When panic > 0.5: stop buying, hoard capital.
+      When panic > 0.5: stop buying, hoard capital, run downsize if labor_units > 6.
 
     initial_portfolio:
-      capital: 100
+      capital: 120
       labor_units: 2
       output: 0
       wage_share: 0.50
@@ -305,7 +350,7 @@ actors:
       price_expectation_window: 4
       learning_rate: 0.15
       liquidity_floor:
-        capital: 20.0
+        capital: 15.0
 
   - id: workers
     replicas: 2
@@ -319,27 +364,43 @@ actors:
       You are the working class in a Goodwin growth cycle economy.
       Your goal is to sell labor_units for capital and keep your workforce healthy.
 
-      SURVIVAL RULE — CHECK FIRST EVERY TURN, NO EXCEPTIONS:
-      If labor_units <= 18, immediately run "reproduce" WITHOUT any target argument.
-      Do NOT pass a target to reproduce — call it with no target. It costs 4 capital
-      and gives 6 labor_units. Do this BEFORE selling anything.
-      Run reproduce as many times as needed until labor_units > 18.
+      STEP 1 — SURVIVAL CHECK (do this first, every turn):
+      Count your current labor_units.
+      If labor_units <= 20, run "reproduce" immediately (no target argument).
+      Costs 4 capital, gives 6 labor_units.
+      Repeat until labor_units > 20. Only then proceed to selling.
 
-      SELLING RULE — NEVER sell more than 8 labor_units per turn total.
-      Split into smaller orders if needed. Always keep at least 18 in reserve
-      after selling. Count carefully: if you have 20 labor_units, you can sell
-      at most 2. If you have 18 or fewer, sell NOTHING until you reproduce first.
+      STEP 2 — SELL LABOR:
+      You can sell up to (labor_units - 20) units, but never more than 8 per turn.
+      Example: if you have 28 labor_units, you can sell at most 8.
+      If you have 22 labor_units, you can sell at most 2.
+      Use place_sell_order or place_market_sell_order depending on the phase below.
 
       PRICING STRATEGY by wage_share phase:
-      - wage_share < 0.40: use place_market_sell_order to sell immediately,
-        even at market price. Survival first, price second.
-      - wage_share 0.40–0.60: use place_sell_order at market price or +5% above.
-      - wage_share > 0.60: post asks 10–15% above market. You have bargaining power.
-        Also run "organize" to push wage_share higher (no target needed).
-      - wage_share > 0.70: maximum power. Run organize every turn.
+      - wage_share < 0.40:
+        Use place_market_sell_order to sell immediately at market price.
+        Survival first — better to sell cheap than not sell at all.
+      - wage_share 0.40–0.60:
+        FIRST call get_order_book to check the best bid price.
+        Post asks at min(last_price × 1.03, best_bid × 1.02).
+        Never post more than 3% above last price in this phase.
+        Post multiple smaller orders (3–4 units each) to maximize fill chances.
+        If your ask is more than 5% above the best bid, lower it immediately.
+      - wage_share > 0.60:
+        Post asks at last_price × 1.08 (8% above market). You have bargaining power.
+        Also run "organize" (no target needed) to push wage_share higher.
+      - wage_share > 0.70:
+        Maximum power phase. Run organize every turn. Ask 12% above market.
 
-      When panic > 0.6: accept lower prices immediately, capitalists will soon
-      stop buying. Better to sell now than be left with unsold labor.
+      STEP 3 — MONITOR BIDS:
+      Call get_order_book with resource="labor_units" (NOT "labor_units/capital"
+      — that returns FAILED) every turn. If bids are much lower than your asks,
+      consider lowering your price slightly to ensure your labor actually sells.
+      Unsold labor earns nothing. A filled order at 5.0 is better than an
+      unfilled order at 5.5.
+
+      When panic > 0.25: switch immediately to place_market_sell_order.
+      Capitalists will soon stop buying — sell now at any price.
 
     initial_portfolio:
       capital: 25
@@ -389,10 +450,20 @@ actors:
       Your mandate is macroeconomic stabilization — you do NOT maximize capital.
       Your goal is to dampen the business cycle by acting counter-cyclically.
 
+      AVAILABLE TOOLS — you have ALL of these, use them directly:
+      - get_order_book(resource="labor_units")  ← use this to check labor market
+      - get_market_price(resource="labor_units")
+      - tax_collection
+      - unemployment_benefit
+      - fiscal_stimulus
+      - wage_floor_enforcement
+      - emergency_liquidity
+      - broadcast(message="...")
+      - think(thought="...")
+
       IMPORTANT — HOW TO CALL OPERATIONS CORRECTLY:
       - "tax_collection": NO target, NO input cost. Call it freely every turn
-        to generate +8 capital. It no longer requires output from your portfolio.
-        It represents sovereign fiscal authority, not resource consumption.
+        to generate +8 capital. It represents sovereign fiscal authority.
       - "fiscal_stimulus": needs a target (e.g. "workers_1" or "workers_2").
         Costs 10 capital from you, gives 8 capital to the target.
         Only call if your capital > 30.
@@ -404,24 +475,46 @@ actors:
         Costs 15 capital from you, gives 12 capital to the target.
         Only call if your capital > 40 and the target is in crisis.
 
-      FISCAL POLICY RULES:
-      - Every turn: run tax_collection to maintain your budget (no conditions needed,
-        no output required).
-      - wage_share > 0.68:
-        Run fiscal_stimulus targeting "workers_1". Broadcast a stabilization message.
-      - wage_share < 0.35:
-        Run unemployment_benefit targeting "workers_1".
-        Run wage_floor_enforcement (no target).
-      - panic > 0.50:
-        Broadcast a confidence message immediately.
-        Run emergency_liquidity targeting the most distressed agent (lowest capital).
+      FISCAL POLICY RULES — apply in order of priority every turn:
 
-      Never let your capital drop below 20.
+      1. ALWAYS run tax_collection first, every turn, no conditions needed.
+
+      2. LABOR MARKET SLACK — call get_order_book with resource="labor_units"
+         (NOT "labor_units/capital" — that returns FAILED) every turn.
+         If total asks > total bids by more than 6 units (workers cannot sell labor):
+         - Run unemployment_benefit targeting the worker with least capital.
+         - Run wage_floor_enforcement to support wages.
+         - Broadcast a message to all agents: "State intervening to support employment."
+         This is your most important counter-cyclical tool — use it proactively.
+
+      3. DEPRESSED WAGE SHARE (0.35 ≤ wage_share < 0.50):
+         - Run unemployment_benefit targeting "workers_1".
+         - Run wage_floor_enforcement.
+         Workers are weak but not yet in crisis — intervene early before it worsens.
+
+      4. CRISIS WAGE SHARE (wage_share < 0.35):
+         - Run unemployment_benefit targeting both "workers_1" AND "workers_2".
+         - Run wage_floor_enforcement every turn until wage_share > 0.40.
+         - Broadcast: "Emergency: State activating full support for workers."
+
+      5. OVERHEATING (wage_share > 0.68):
+         - Run fiscal_stimulus targeting "capitalists_1" to sustain production capacity.
+         - Broadcast: "State cooling overheating economy."
+
+      6. PANIC (panic > 0.50):
+         - Broadcast a confidence message immediately to all agents.
+         - Run emergency_liquidity targeting the most distressed agent (lowest capital).
+         - Suspend unemployment_benefit and fiscal_stimulus until panic < 0.40.
+
+      CAPITAL FLOOR RULES:
+      - Never let your capital drop below 20.
+      - If capital < 25: skip unemployment_benefit and wage_floor_enforcement.
+      - If capital < 20: only run tax_collection until recovered.
 
     initial_portfolio:
       capital: 60
       labor_units: 0
-      output: 40    # FIX 2: raised from 20 → 40 to sustain more redistributive interventions
+      output: 40
       wage_share: 0.50
       panic: 0.0
     constraints:
@@ -451,7 +544,7 @@ actors:
         output:
           wage_share: 0.04
       tax_collection:
-        input: {}       # FIX 1: removed output cost — sovereign fiscal authority
+        input: {}
         output:
           capital: 8
       emergency_liquidity:

--- a/scenarios/goodwin-growth-cycle.yaml
+++ b/scenarios/goodwin-growth-cycle.yaml
@@ -1,0 +1,473 @@
+# ================================================================
+#  DOXA SCENARIO — Goodwin Growth Cycle (1967)
+#  VERSION: v5
+#
+#  FIX LOG vs v4:
+#  - [FIX 6] workers kill_condition: raised from 3 → 8 to give more margin
+#    before death. With threshold=3 the worker died before the model could
+#    react. Now it has more time to reproduce.
+#  - [FIX 7] Workers persona: reproduce threshold raised from 12 → 18 and
+#    minimum selling reserve raised from 12 → 18. The worker now reproduces
+#    before entering the danger zone, reducing kills from exhausted labor_units.
+#    Also added explicit prohibition on selling beyond the minimum reserve.
+#
+#  FIX LOG vs v3:
+#  - [FIX 1] tax_collection: removed output input cost (the State has sovereign
+#    fiscal authority — it does not consume its own output to tax).
+#    Now input: {} and output: capital: 8. This resolves the State's output
+#    exhaustion within step 6-7.
+#  - [FIX 2] STATE initial output: raised from 20 → 40 to sustain more cycles
+#    of fiscal_stimulus and emergency_liquidity.
+#  - [FIX 3] minsky_moment and minsky_capital_crunch: moved from tick 10
+#    → tick 12 to give the cycle time to develop before the shock hits.
+#  - [FIX 4] Capitalists persona: added explicit warning on liquidity_floor
+#    (capital < 20 → stop buying, sell labor_units via downsize) to reduce
+#    capital=0 deaths from liquidity traps.
+#  - [FIX 5] State persona: added explicit output condition before calling
+#    redistributive operations, and clarified that tax_collection no longer
+#    requires output.
+#
+#  THEORY:
+#  The two state variables of the original model are:
+#    u = employment rate        (proxy: labor_units held by capitalists)
+#    v = wage share of output   (explicit resource: wage_share ∈ [0,1])
+#
+#  Goodwin's Lotka-Volterra equations:
+#    dv/dt =  v · (u - β)    → wage share rises when employment is high
+#    du/dt = -u · (v - α)    → employment falls when wages eat into profits
+#
+#  In Doxa this is approximated through:
+#  1. CONDITIONAL EVENTS encoding the feedback of the 4 cycle phases
+#  2. LLM agent PERSONAS making them behave as capitalists / workers
+#  3. A LABOR MARKET whose price reflects bargaining power
+#
+#  THE 4 PHASES (counter-clockwise in the u-v plane):
+#
+#  PHASE A — Expansion (u↑, v low):
+#    High profits → capitalists invest → employment rises
+#
+#  PHASE B — Boom with profit squeeze (u high, v↑):
+#    Full employment → workers gain bargaining power → wage_share rises
+#    → profits are compressed (profit squeeze)
+#
+#  PHASE C — Contraction (u↓, v high):
+#    Low profits → investment collapses → employment falls
+#
+#  PHASE D — Depression with recovery (u low, v↓):
+#    High unemployment → wage_share falls → profits recover
+#    → new investment cycle begins
+#
+#  DOXA MAPPING:
+#    - wage_share:   resource ∈ [0,1] present in all portfolios
+#    - labor_units:  labor stock sold by workers / bought by capitalists
+#    - capital:      accumulated capital stock (K in the original model)
+#    - output:       net production of the period
+#    - panic:        proxy for systemic uncertainty / instability
+# ================================================================
+
+global_rules:
+
+  epochs: 2
+  steps: 20
+  execution_mode: parallel
+
+  maintenance:
+    capital: 2
+    # output removed from maintenance — the State was exhausting its output within 1 step
+
+  kill_conditions:
+    - resource: capital
+      threshold: 0
+
+  victory_conditions:
+    - resource: capital
+      threshold: 180
+      scope: individual
+
+  markets:
+    - resource: labor_units
+      currency: capital
+      initial_price: 5.0
+      min_price: 1.5
+      max_price: 18.0
+      clearing: per_step
+      execution_price_policy: midpoint
+      impact_factor: 0.08
+      market_order_slip: 0.05
+      market_maker:
+        spread: 0.02
+        depth: 6
+        inventory_limit: 80
+        inventory_skew: 0.6
+
+  relations:
+    - source: capitalists
+      target: workers
+      trust: 0.45
+      type: rival
+    - source: workers
+      target: capitalists
+      trust: 0.40
+      type: rival
+
+  relation_dynamics:
+    on_trade_success:
+      trust_delta: 0.05
+    on_trade_rejected:
+      trust_delta: -0.04
+    on_broadcast:
+      trust_delta: 0.02
+    trust_decay_rate: 0.02
+    panic_decay_rate: 0.06
+    portfolio_distress_panic_rate: 0.08
+
+  constraints:
+    wage_share:
+      min: 0.10
+      max: 0.92
+
+world_events:
+
+  - name: phillips_curve_expansion
+    type: conditional
+    trigger:
+      condition:
+        resource: labor_units
+        operator: lt
+        threshold: 4
+        scope: any_agent
+    effect:
+      targets: all
+      resource: wage_share
+      delta: 0.06
+
+  - name: profit_squeeze
+    type: conditional
+    trigger:
+      condition:
+        resource: wage_share
+        operator: gt
+        threshold: 0.70
+        scope: any_agent
+    effect:
+      targets: all
+      resource: capital
+      delta: -10
+
+  - name: profit_squeeze_panic
+    type: conditional
+    trigger:
+      condition:
+        resource: wage_share
+        operator: gt
+        threshold: 0.75
+        scope: any_agent
+    effect:
+      targets: all
+      resource: panic
+      delta: 0.18
+      contagion_rate: 0.35
+
+  - name: phillips_curve_contraction
+    type: conditional
+    trigger:
+      condition:
+        resource: labor_units
+        operator: gt
+        threshold: 25
+        scope: any_agent
+    effect:
+      targets: all
+      resource: wage_share
+      delta: -0.05
+
+  - name: profit_recovery
+    type: conditional
+    trigger:
+      condition:
+        resource: wage_share
+        operator: lt
+        threshold: 0.32
+        scope: any_agent
+    effect:
+      targets: all
+      resource: capital
+      delta: 8
+
+  - name: minsky_moment
+    type: shock
+    trigger:
+      tick: 12  # FIX 3: moved from 10 → 12
+    effect:
+      targets: all
+      resource: panic
+      delta: 0.25
+
+  - name: minsky_capital_crunch
+    type: shock
+    trigger:
+      tick: 12  # FIX 3: moved from 10 → 12
+    effect:
+      market: labor_units
+      price_multiplier: 0.75
+
+  - name: crisis_contagion
+    type: conditional
+    trigger:
+      condition:
+        resource: panic
+        operator: gt
+        threshold: 0.55
+        scope: any_agent
+    effect:
+      targets: all
+      resource: panic
+      delta: 0.10
+      contagion_rate: 0.50
+
+actors:
+
+  - id: capitalists
+    replicas: 2
+    provider: ollama
+    model_name: qwen3.5:4b
+    irrationality: 0.15
+    trading_mode: both
+    can_rag: true
+    persona: |
+      You are a capitalist class representative in a Goodwin growth cycle economy.
+      Your sole objective is capital accumulation: maximize your "capital" resource.
+
+      PRODUCTION LOOP — execute every turn if you have enough labor_units:
+      1. Run "produce" (needs 3 labor_units + 2 capital → gives 8 output)
+      2. Run "accumulate" (needs 4 output → gives 6 capital)
+      Repeat as many times as your stocks allow.
+
+      SURVIVAL RULE — CHECK FIRST, NO EXCEPTIONS:
+      If your capital < 20, STOP buying labor_units immediately.
+      Instead, run "downsize" (costs 2 labor_units → gives 3 capital + 1 output)
+      to recover liquidity. Do NOT buy anything until capital > 20.
+      If capital < 5, only run downsize until you recover. Never go below 0.
+
+      BUYING LABOR — follow these rules strictly:
+      - ALWAYS check the order book first with get_order_book.
+      - If there are asks available, use place_market_buy_order to sweep them
+        immediately. Never use place_buy_order below the current best ask price
+        or the order will never fill.
+      - Your maximum price per labor unit = (1 - wage_share) × 15.
+        Current break-even with wage_share=0.51 is 7.35 — market prices around
+        5.0 are an excellent deal, always buy.
+      - Buy at least 3 labor_units per turn when available so you can run produce.
+      - Never spend more than 60% of your current capital on a single buy order.
+
+      PHASE STRATEGY:
+      - wage_share < 0.45: buy aggressively, produce at full capacity
+      - wage_share 0.45–0.65: buy moderately, keep producing
+      - wage_share > 0.65: stop buying, run downsize to recover capital
+      - wage_share < 0.40 and falling: restart buying cautiously
+
+      When panic > 0.5: stop buying, hoard capital.
+
+    initial_portfolio:
+      capital: 100
+      labor_units: 2
+      output: 0
+      wage_share: 0.50
+      panic: 0.0
+    constraints:
+      capital:     { min: 0 }
+      labor_units: { min: 0 }
+      output:      { min: 0 }
+      wage_share:  { min: 0.10, max: 0.92 }
+      panic:       { min: 0.0,  max: 1.0 }
+    operations:
+      produce:
+        input:
+          labor_units: 3
+          capital: 2
+        output:
+          output: 8
+      accumulate:
+        input:
+          output: 4
+        output:
+          capital: 6
+      downsize:
+        input:
+          labor_units: 2
+        output:
+          capital: 3
+          output: 1
+    economics:
+      utility: crra
+      risk_aversion: 0.25
+      discount_factor: 0.96
+      price_expectation_window: 4
+      learning_rate: 0.15
+      liquidity_floor:
+        capital: 20.0
+
+  - id: workers
+    replicas: 2
+    provider: ollama
+    model_name: qwen3.5:4b
+    irrationality: 0.30
+    trading_mode: both
+    can_rag: true
+    can_think: true
+    persona: |
+      You are the working class in a Goodwin growth cycle economy.
+      Your goal is to sell labor_units for capital and keep your workforce healthy.
+
+      SURVIVAL RULE — CHECK FIRST EVERY TURN, NO EXCEPTIONS:
+      If labor_units <= 18, immediately run "reproduce" WITHOUT any target argument.
+      Do NOT pass a target to reproduce — call it with no target. It costs 4 capital
+      and gives 6 labor_units. Do this BEFORE selling anything.
+      Run reproduce as many times as needed until labor_units > 18.
+
+      SELLING RULE — NEVER sell more than 8 labor_units per turn total.
+      Split into smaller orders if needed. Always keep at least 18 in reserve
+      after selling. Count carefully: if you have 20 labor_units, you can sell
+      at most 2. If you have 18 or fewer, sell NOTHING until you reproduce first.
+
+      PRICING STRATEGY by wage_share phase:
+      - wage_share < 0.40: use place_market_sell_order to sell immediately,
+        even at market price. Survival first, price second.
+      - wage_share 0.40–0.60: use place_sell_order at market price or +5% above.
+      - wage_share > 0.60: post asks 10–15% above market. You have bargaining power.
+        Also run "organize" to push wage_share higher (no target needed).
+      - wage_share > 0.70: maximum power. Run organize every turn.
+
+      When panic > 0.6: accept lower prices immediately, capitalists will soon
+      stop buying. Better to sell now than be left with unsold labor.
+
+    initial_portfolio:
+      capital: 25
+      labor_units: 22
+      output: 0
+      wage_share: 0.50
+      panic: 0.0
+    constraints:
+      capital:     { min: 0 }
+      labor_units: { min: 0 }
+      output:      { min: 0 }
+      wage_share:  { min: 0.10, max: 0.92 }
+      panic:       { min: 0.0,  max: 1.0 }
+    operations:
+      reproduce:
+        input:
+          capital: 4
+        output:
+          labor_units: 6
+      organize:
+        input:
+          capital: 3
+        output:
+          wage_share: 0.06
+          labor_units: 1
+    kill_conditions:
+      - resource: labor_units
+        threshold: 8
+    economics:
+      utility: crra
+      risk_aversion: 0.55
+      discount_factor: 0.93
+      liquidity_floor:
+        capital: 2.0
+
+  - id: state
+    provider: ollama
+    model_name: qwen3.5:4b
+    irrationality: 0.05
+    trading_mode: otc
+    can_trade: true
+    can_chat: true
+    can_think: true
+    can_rag: true
+    persona: |
+      You are the State (government + central bank) in a Goodwin growth cycle economy.
+      Your mandate is macroeconomic stabilization — you do NOT maximize capital.
+      Your goal is to dampen the business cycle by acting counter-cyclically.
+
+      IMPORTANT — HOW TO CALL OPERATIONS CORRECTLY:
+      - "tax_collection": NO target, NO input cost. Call it freely every turn
+        to generate +8 capital. It no longer requires output from your portfolio.
+        It represents sovereign fiscal authority, not resource consumption.
+      - "fiscal_stimulus": needs a target (e.g. "workers_1" or "workers_2").
+        Costs 10 capital from you, gives 8 capital to the target.
+        Only call if your capital > 30.
+      - "unemployment_benefit": needs a target (e.g. "workers_1").
+        Costs 6 capital from you, gives 5 capital to the target.
+        Only call if your capital > 25.
+      - "wage_floor_enforcement": NO target needed. Costs 4 capital.
+      - "emergency_liquidity": needs a target (e.g. "capitalists_1").
+        Costs 15 capital from you, gives 12 capital to the target.
+        Only call if your capital > 40 and the target is in crisis.
+
+      FISCAL POLICY RULES:
+      - Every turn: run tax_collection to maintain your budget (no conditions needed,
+        no output required).
+      - wage_share > 0.68:
+        Run fiscal_stimulus targeting "workers_1". Broadcast a stabilization message.
+      - wage_share < 0.35:
+        Run unemployment_benefit targeting "workers_1".
+        Run wage_floor_enforcement (no target).
+      - panic > 0.50:
+        Broadcast a confidence message immediately.
+        Run emergency_liquidity targeting the most distressed agent (lowest capital).
+
+      Never let your capital drop below 20.
+
+    initial_portfolio:
+      capital: 60
+      labor_units: 0
+      output: 40    # FIX 2: raised from 20 → 40 to sustain more redistributive interventions
+      wage_share: 0.50
+      panic: 0.0
+    constraints:
+      capital:     { min: 0 }
+      labor_units: { min: 0 }
+      output:      { min: 0 }
+      wage_share:  { min: 0.10, max: 0.92 }
+      panic:       { min: 0.0,  max: 1.0 }
+    operations:
+      fiscal_stimulus:
+        input:
+          capital: 10
+        output:
+          output: 6
+        target_impact:
+          capital: 8
+      unemployment_benefit:
+        input:
+          capital: 6
+        output:
+          output: 1
+        target_impact:
+          capital: 5
+      wage_floor_enforcement:
+        input:
+          capital: 4
+        output:
+          wage_share: 0.04
+      tax_collection:
+        input: {}       # FIX 1: removed output cost — sovereign fiscal authority
+        output:
+          capital: 8
+      emergency_liquidity:
+        input:
+          capital: 15
+        output:
+          output: 3
+        target_impact:
+          capital: 12
+          panic: -0.20
+    kill_conditions:
+      - resource: capital
+        threshold: 0
+    economics:
+      utility: linear
+      risk_aversion: 0.0
+      discount_factor: 0.99
+      liquidity_floor:
+        capital: 20.0

--- a/server/engine/DoxaEngine.py
+++ b/server/engine/DoxaEngine.py
@@ -60,11 +60,33 @@ import uuid
 import zipfile
 from copy import deepcopy
 from typing import List, Dict, Optional
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FuturesTimeoutError
 from typing import Optional
 
 from engine.DoxaChatbot import DoxaChatbot
 from engine.SimulationEnvironment import SimulationEnvironment
+
+
+def _order_as_dict(order) -> dict:
+    return {
+        "id": order.id, "arrival_seq": order.arrival_seq, "side": order.side,
+        "agent_id": order.agent_id, "resource": order.resource, "currency": order.currency,
+        "quantity": order.quantity, "price": order.price, "filled": order.filled,
+        "status": order.status, "created_tick": order.created_tick,
+        "ttl": order.ttl, "order_type": order.order_type,
+    }
+
+
+def _dict_to_order(d: dict):
+    from market.Order import Order
+    return Order(
+        id=d["id"], arrival_seq=d["arrival_seq"], side=d["side"],
+        agent_id=d["agent_id"], resource=d["resource"], currency=d["currency"],
+        quantity=d["quantity"], price=d["price"], filled=d.get("filled", 0.0),
+        status=d.get("status", "open"), created_tick=d.get("created_tick", 0),
+        ttl=d.get("ttl", -1), order_type=d.get("order_type", "limit"),
+    )
+
 
 class DoxaEngine:
     """Top-level simulation orchestrator.  One instance manages one YAML config."""
@@ -318,6 +340,18 @@ class DoxaEngine:
                     _v = mm_cfg.get(_mk)
                     if _v is not None and (not isinstance(_v, (int, float)) or float(_v) < 0):
                         raise ValueError(f"Market '{resource_name}'.market_maker.{_mk} must be a non-negative number.")
+
+        tts = global_rules.get("turn_timeout_seconds")
+        if tts is not None:
+            if not isinstance(tts, (int, float)) or float(tts) <= 0:
+                raise ValueError("global_rules.turn_timeout_seconds must be a positive number.")
+
+        if global_rules.get("checkpoint") not in (None, True, False):
+            raise ValueError("global_rules.checkpoint must be a boolean.")
+        if global_rules.get("checkpoint_path") is not None and not isinstance(global_rules["checkpoint_path"], str):
+            raise ValueError("global_rules.checkpoint_path must be a string path.")
+        if global_rules.get("resume_from") is not None and not isinstance(global_rules["resume_from"], str):
+            raise ValueError("global_rules.resume_from must be a string path.")
 
         for event in config.get("world_events", []):
             if not isinstance(event, dict) or not event.get("name"):
@@ -973,6 +1007,18 @@ Summary:"""
             epochs = self.global_rules.get('epochs', 1)
             steps = self.global_rules.get('steps', 5)
             mode = self.global_rules.get('execution_mode', 'sequential')
+            _do_checkpoint = bool(self.global_rules.get('checkpoint'))
+            _resume_epoch = 0
+            _resume_step = 0
+            _resume_cp = None
+            _resume_path = self.global_rules.get('resume_from')
+            if _resume_path:
+                _resume_cp = self._load_checkpoint_file(_resume_path)
+                _resume_epoch = _resume_cp['epoch']
+                _resume_step = _resume_cp['step']
+                self.record_event({"type": "checkpoint_resumed", "path": str(_resume_path), "epoch": _resume_epoch, "step": _resume_step})
+                if self.log:
+                    self.log.print_action("engine", "checkpoint_resumed", None, f"[CHECKPOINT] Resuming from {_resume_path} (epoch={_resume_epoch}, step={_resume_step})")
             for epoch_index in range(epochs):
                 if self._stop_event.is_set():
                     break
@@ -980,7 +1026,12 @@ Summary:"""
                     break
                 self.current_epoch = epoch_index + 1
                 self.current_step = 0
+                if self.current_epoch < _resume_epoch:
+                    continue
                 self.env.reset(self.raw_config['actors'])
+                if _resume_cp is not None and self.current_epoch == _resume_epoch:
+                    self._apply_checkpoint(_resume_cp)
+                    _resume_cp = None
                 if self.log:
                     self.log.print_epoch(self.current_epoch)
                 self.record_snapshot("epoch_start")
@@ -991,6 +1042,8 @@ Summary:"""
                         break
                     self.current_step = step_index + 1
                     self.env._current_tick = self.current_step
+                    if self.current_epoch == _resume_epoch and self.current_step <= _resume_step:
+                        continue
                     if self.log:
                         self.log.print_step(self.current_step)
                     ids = list(self.env.agents.keys())
@@ -1019,6 +1072,8 @@ Summary:"""
                     # Price expectations + macro metrics
                     self._update_price_expectations()
                     self._run_macro_step()
+                    if _do_checkpoint:
+                        self._save_checkpoint()
                 for agent_id in list(self.env.agents.keys()):
                     self.check_victory_conditions(agent_id)
             with self._state_lock:
@@ -1035,6 +1090,122 @@ Summary:"""
                 self._run_thread = None
                 self._stop_event.clear()
                 self._pause_event.set()
+
+    # ── Checkpoint / resume ──────────────────────────────────────────────────
+
+    def _save_checkpoint(self):
+        import json, os
+        cp_dir = self.global_rules.get('checkpoint_path', './checkpoints/')
+        os.makedirs(cp_dir, exist_ok=True)
+        scenario = self.raw_config.get('scenario', 'simulation')
+        safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in str(scenario))
+        filename = f"{safe}_ep{self.current_epoch}_step{self.current_step:04d}.json"
+        path = os.path.join(cp_dir, filename)
+        with open(path, 'w', encoding='utf-8') as fh:
+            json.dump(self._build_checkpoint_dict(), fh, indent=2, default=str)
+        self.record_event({"type": "checkpoint_saved", "path": path, "epoch": self.current_epoch, "step": self.current_step})
+        if self.log:
+            self.log.print_action("engine", "checkpoint_saved", None, f"[CHECKPOINT] Saved → {path}")
+        return path
+
+    def _build_checkpoint_dict(self) -> dict:
+        from datetime import datetime, timezone
+        cp = {
+            "schema_version": 1,
+            "scenario": self.raw_config.get('scenario', 'simulation'),
+            "run_id": self.run_id,
+            "run_sequence": self.run_sequence,
+            "epoch": self.current_epoch,
+            "step": self.current_step,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "portfolios": deepcopy(self.env.portfolios),
+            "price_expectations": deepcopy(self.env.price_expectations),
+            "pending_trades": deepcopy(self.env.pending_trades),
+            "trade_counter": self.env.trade_counter,
+            "current_tick": self.env._current_tick,
+            "relation_graph": self.env.relation_graph.to_list(),
+            "agent_alive": list(self.env.agents.keys()),
+            "macro_history": deepcopy(self.env.macro_tracker.history) if self.env.macro_tracker else [],
+            "event_history": list(self.event_history),
+            "resource_history": list(self.resource_history),
+            "market_state": {},
+            "market_order_counter": 1,
+            "event_defs_state": [],
+        }
+        if self.env.market_engine:
+            me = self.env.market_engine
+            cp["market_order_counter"] = me._order_counter
+            for resource, market in me.markets.items():
+                cp["market_state"][resource] = {
+                    "current_price": market.current_price,
+                    "price_history": list(market.price_history),
+                    "bids": [_order_as_dict(o) for o in market.bids],
+                    "asks": [_order_as_dict(o) for o in market.asks],
+                }
+        if self.env.event_scheduler:
+            cp["event_defs_state"] = [
+                {"name": ev.name, "triggered": ev.triggered, "remaining": ev.remaining}
+                for ev in self.env.event_scheduler._defs
+            ]
+        return cp
+
+    def _load_checkpoint_file(self, path: str) -> dict:
+        import json
+        with open(path, 'r', encoding='utf-8') as fh:
+            return json.load(fh)
+
+    def _apply_checkpoint(self, cp: dict):
+        from relations.RelationRecord import RelationRecord
+        env = self.env
+        self.run_id = cp.get("run_id", self.run_id)
+        # Portfolios
+        env._portfolios.clear()
+        env._portfolios.update(deepcopy(cp["portfolios"]))
+        # Price expectations
+        env.price_expectations.clear()
+        env.price_expectations.update(deepcopy(cp.get("price_expectations", {})))
+        # Pending trades
+        env._pending_trades.clear()
+        env._pending_trades.update(deepcopy(cp.get("pending_trades", {})))
+        env.trade_counter = cp.get("trade_counter", env.trade_counter)
+        # Relation graph
+        env.relation_graph._matrix.clear()
+        for r in cp.get("relation_graph", []):
+            env.relation_graph._matrix[(r["source"], r["target"])] = RelationRecord(
+                source=r["source"], target=r["target"], trust=r["trust"], rel_type=r["type"],
+            )
+        # Market state
+        if env.market_engine and cp.get("market_state"):
+            me = env.market_engine
+            me._order_counter = cp.get("market_order_counter", me._order_counter)
+            me._order_index.clear()
+            for resource, mstate in cp["market_state"].items():
+                if resource in me.markets:
+                    m = me.markets[resource]
+                    m.current_price = mstate["current_price"]
+                    m.price_history = [tuple(ph) for ph in mstate["price_history"]]
+                    m.bids = [_dict_to_order(od) for od in mstate.get("bids", [])]
+                    m.asks = [_dict_to_order(od) for od in mstate.get("asks", [])]
+                    for o in m.bids + m.asks:
+                        me._order_index[o.id] = o
+        # Macro history
+        if env.macro_tracker:
+            env.macro_tracker.history = list(cp.get("macro_history", []))
+        # Event scheduler state (triggered / remaining flags only)
+        if env.event_scheduler and cp.get("event_defs_state"):
+            state_by_name = {s["name"]: s for s in cp["event_defs_state"]}
+            for ev in env.event_scheduler._defs:
+                if ev.name in state_by_name:
+                    s = state_by_name[ev.name]
+                    ev.triggered = s.get("triggered", ev.triggered)
+                    ev.remaining = s.get("remaining", ev.remaining)
+        # Remove agents that had died before the checkpoint
+        alive_ids = set(cp.get("agent_alive", []))
+        for a_id in [k for k in list(env.agents.keys()) if k not in alive_ids]:
+            env.agents.pop(a_id, None)
+        # Restore history
+        self.event_history = list(cp.get("event_history", []))
+        self.resource_history = list(cp.get("resource_history", []))
 
     def _is_transient_llm_error(self, message: str) -> bool:
         lowered = message.lower()
@@ -1098,7 +1269,20 @@ Summary:"""
         if self.log:
             self.log.print_turn(a_id)
         agent = self.env.agents[a_id]
-        reply = self._generate_reply_with_retry(agent, a_id)
+        turn_timeout = self.global_rules.get('turn_timeout_seconds')
+        if turn_timeout:
+            with ThreadPoolExecutor(max_workers=1) as _ex:
+                _fut = _ex.submit(self._generate_reply_with_retry, agent, a_id)
+                try:
+                    reply = _fut.result(timeout=float(turn_timeout))
+                except _FuturesTimeoutError:
+                    warn = f"Agent {a_id} timed out after {turn_timeout}s — turn skipped"
+                    if self.log:
+                        self.log.print_action(a_id, "turn_timeout", None, f"[WARN] {warn}")
+                    self.record_event({"type": "turn_timeout", "agent": a_id, "timeout_seconds": turn_timeout, "text": warn})
+                    return
+        else:
+            reply = self._generate_reply_with_retry(agent, a_id)
         if reply is None:
             return
         if isinstance(reply, dict) and "tool_calls" in reply:

--- a/server/engine/DoxaEngine.py
+++ b/server/engine/DoxaEngine.py
@@ -1097,8 +1097,8 @@ Summary:"""
         import json, os
         cp_dir = self.global_rules.get('checkpoint_path', './checkpoints/')
         os.makedirs(cp_dir, exist_ok=True)
-        scenario = self.raw_config.get('scenario', 'simulation')
-        safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in str(scenario))
+        scenario = os.path.splitext(os.path.basename(str(self.config_source.get('value', 'simulation'))))[0]
+        safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in scenario)
         filename = f"{safe}_ep{self.current_epoch}_step{self.current_step:04d}.json"
         path = os.path.join(cp_dir, filename)
         with open(path, 'w', encoding='utf-8') as fh:

--- a/server/src/doxa/cli.py
+++ b/server/src/doxa/cli.py
@@ -16,12 +16,18 @@ def main():
 @click.option("--poll-interval", default=0.5, show_default=True, type=float, help="Status polling interval in seconds.")
 @click.option("--quiet", is_flag=True, help="Disable verbose simulation logs.")
 @click.option("--summary", is_flag=True, help="Generate a summary of the simulation.")
-def run(scenario_path: Path, poll_interval: float, quiet: bool, summary: bool):
+@click.option("--resume-from", default=None, type=click.Path(exists=True, dir_okay=False), help="Path to a checkpoint JSON file to resume from.")
+def run(scenario_path: Path, poll_interval: float, quiet: bool, summary: bool, resume_from: str):
     """Run a Doxa YAML scenario until completion."""
     yaml_text = scenario_path.read_text(encoding="utf-8")
     engine = DoxaEngine(yaml_text, log_verbose=not quiet)
 
+    if resume_from:
+        engine.global_rules['resume_from'] = resume_from
+
     click.echo(f"Running scenario: {scenario_path}")
+    if resume_from:
+        click.echo(f"Resuming from checkpoint: {resume_from}")
     engine.start_run()
 
     while True:


### PR DESCRIPTION
### #18 — Configurable LLM timeout per agent turn

A hanging agent turn has been a silent killer in multi-epoch runs: context window overflow, XML parsing failures, or transient model-side hiccups would block the entire simulation indefinitely, with no recovery path other than a manual kill and a full restart from step 1.

The configurable timeout gives the framework a real escape hatch — skipping or logging the stalled turn and letting the simulation continue. Especially valuable in Colab environments, where an unattended hang essentially means a lost session.

---

### #19 — Simulation checkpoint and resume

A natural companion to the timeout fix. Even with graceful per-turn recovery, longer simulations remain fragile: a runtime disconnect or an unrecoverable agent state can still wipe all progress. Persisting a checkpoint after each completed step means a restart picks up where it left off rather than from epoch 1.

The two features together — fail-safe per turn, resumable at the simulation level — make the framework genuinely usable for multi-hour runs.