### PR TITLE
feat(engine): configurable panic resource name

### DIFF
--- a/CONFIG_YAML_REFERENCE.md
+++ b/CONFIG_YAML_REFERENCE.md
@@ -218,8 +218,25 @@ global_rules:
 | `on_trade_rejected.trust_delta` | number | `-0.02` | Trust change applied from the **rejector toward the proposer** when a trade is rejected. |
 | `on_broadcast.trust_delta` | number | `0.01` | Trust boost applied from the broadcasting agent to every agent that receives the broadcast. |
 | `trust_decay_rate` | number | `0.0` | Per-step decay toward neutral (0.5) applied to **all** trust edges after maintenance. |
-| `panic_decay_rate` | number | `0.0` | Per-step reduction of the `panic` resource toward 0 applied to every agent after maintenance. |
+| `panic_decay_rate` | number | `0.0` | Per-step reduction of the panic resource (see `panic_resource` below) toward 0 applied to every agent after maintenance. |
 | `portfolio_distress_panic_rate` | number | `0.0` | When > 0, agents whose total portfolio value dropped compared to the previous step gain `drop_fraction × distress_rate` panic each step. |
+
+> **`panic_resource`** (top-level `global_rules` key, not nested under
+> `relation_dynamics` — default: `"panic"`). Name of the bounded resource
+> that `panic_decay_rate`, `portfolio_distress_panic_rate`, and the
+> `system_panic` macro metric all read/write. Every launch scenario uses
+> the default, so no existing YAML needs to change. Non-economic scenarios
+> can point this at a domain-appropriate resource instead — e.g. a
+> behavioral-health scenario might set `panic_resource: relapse_risk` to
+> reuse this decay/contagion/metric machinery without calling anything
+> literally "panic":
+> ```yaml
+> global_rules:
+>   panic_resource: relapse_risk
+>   relation_dynamics:
+>     panic_decay_rate: 0.06
+>     portfolio_distress_panic_rate: 0.08
+> ```
 
 ---
 

--- a/server/engine/DoxaEngine.py
+++ b/server/engine/DoxaEngine.py
@@ -754,6 +754,11 @@ class DoxaEngine:
         rel_dyn = self.global_rules.get("relation_dynamics", {})
         trust_decay = rel_dyn.get("trust_decay_rate", 0.0)
         panic_decay = rel_dyn.get("panic_decay_rate", 0.0)
+        # Resource name treated as "panic" by the built-in decay / portfolio-
+        # distress feedback below. Defaults to "panic" (backward compatible);
+        # non-economic scenarios can point this at e.g. "relapse_risk" via
+        # global_rules.panic_resource without losing this machinery.
+        panic_resource = self.global_rules.get("panic_resource", "panic")
 
         # Hold the shared environment lock for the entire maintenance pass so that
         # portfolio mutations are visible atomically to any agent threads that
@@ -765,9 +770,9 @@ class DoxaEngine:
                 for resource_name, amount in maintenance.items():
                     self.env.portfolios[agent_id][resource_name] = self.env.portfolios[agent_id].get(resource_name, 0) - amount
                 # Decay panic resource toward 0 (clamp at 0)
-                if panic_decay and "panic" in self.env.portfolios[agent_id]:
-                    current_panic = self.env.portfolios[agent_id]["panic"]
-                    self.env.portfolios[agent_id]["panic"] = max(0.0, current_panic - panic_decay)
+                if panic_decay and panic_resource in self.env.portfolios[agent_id]:
+                    current_panic = self.env.portfolios[agent_id][panic_resource]
+                    self.env.portfolios[agent_id][panic_resource] = max(0.0, current_panic - panic_decay)
                 # Portfolio distress → panic feedback
                 distress_rate = rel_dyn.get("portfolio_distress_panic_rate", 0.0)
                 if distress_rate > 0.0 and self.resource_history:
@@ -779,8 +784,8 @@ class DoxaEngine:
                         if prev_total > 0:
                             drop = (prev_total - curr_total) / prev_total
                             if drop > 0:
-                                self.env.portfolios[agent_id]["panic"] = (
-                                    self.env.portfolios[agent_id].get("panic", 0.0)
+                                self.env.portfolios[agent_id][panic_resource] = (
+                                    self.env.portfolios[agent_id].get(panic_resource, 0.0)
                                     + drop * distress_rate
                                 )
                 kill_conds = self.global_rules.get("kill_conditions", []) + self.env.agents[agent_id].config.get("kill_conditions", [])

--- a/server/engine/MacroTracker.py
+++ b/server/engine/MacroTracker.py
@@ -9,8 +9,13 @@ Metrics captured
   Herfindahl-Hirschman Index (HHI) across all agent portfolios.
 * **Market price volatility** \u2014 rolling standard deviation over the last
   30 price-history entries for each configured market.
-* **System panic** \u2014 mean ``panic`` resource value across all agents
-  (a proxy for collective distress).
+* **System panic** \u2014 mean value of the configured *panic resource*
+  across all agents (a proxy for collective distress). Defaults to the
+  resource literally named ``panic``, but any scenario can point this at
+  a differently-named bounded resource via ``global_rules.panic_resource``
+  (e.g. ``relapse_risk`` in a clinical/behavioral-health scenario) without
+  losing this metric. The output key is always ``system_panic`` regardless
+  of the underlying resource name, so API/frontend consumers don't change.
 
 History is capped at the 500 most recent snapshots to bound memory use.
 """
@@ -31,8 +36,19 @@ class MacroTracker:
         3. ``latest()`` / ``history`` are exposed via the API.
     """
 
-    def __init__(self):
+    def __init__(self, panic_resource: str = "panic"):
+        """
+        Args:
+            panic_resource: Name of the bounded [0,1]-style resource treated
+                as "system panic" for the ``system_panic`` aggregate metric.
+                Defaults to ``"panic"`` for backward compatibility with
+                existing scenarios (e.g. goodwin-growth-cycle.yaml,
+                info-diffusion.yaml). Scenarios in other domains can set
+                ``global_rules.panic_resource`` to reuse this metric under
+                a domain-appropriate name.
+        """
         self.history: List[Dict] = []  # Rolling list of per-tick snapshots (max 500)
+        self.panic_resource = panic_resource
 
     def reset(self):
         """Clear history at the start of a new epoch."""
@@ -94,11 +110,13 @@ class MacroTracker:
                 }
         snap["market_stats"] = market_stats
 
-        # ── 3. System-wide panic (mean across agents that hold a panic resource) ──
+        # ── 3. System-wide panic (mean across agents that hold the configured
+        #        panic_resource, "panic" by default — see __init__ docstring) ──
+        pr = self.panic_resource
         panic_vals = [
-            p.get("panic", 0.0)
+            p.get(pr, 0.0)
             for p in portfolios.values()
-            if "panic" in p and isinstance(p["panic"], (int, float))
+            if pr in p and isinstance(p[pr], (int, float))
         ]
         snap["system_panic"] = round(sum(panic_vals) / len(panic_vals), 4) if panic_vals else 0.0
 

--- a/server/engine/SimulationEnvironment.py
+++ b/server/engine/SimulationEnvironment.py
@@ -86,7 +86,13 @@ class SimulationEnvironment:
         self.market_engine: Optional[MarketEngine] = self._build_market_engine()
         self.event_scheduler: Optional[WorldEventScheduler] = self._build_event_scheduler()
         # Macro and agent-economics subsystems (no reset required until reset() is called)
-        self.macro_tracker: MacroTracker = MacroTracker()
+        # panic_resource lets non-economic scenarios (e.g. clinical/behavioral-health)
+        # reuse the panic_decay / portfolio_distress_panic_rate / system_panic
+        # machinery under a domain-appropriate resource name. Defaults to "panic"
+        # so every existing scenario is unaffected.
+        self.macro_tracker: MacroTracker = MacroTracker(
+            panic_resource=self.global_rules.get("panic_resource", "panic")
+        )
         self.agent_economics_map: Dict[str, AgentEconomics] = {}
         self.price_expectations: Dict[str, Dict[str, float]] = {}  # agent_id → resource → EWA price
 

--- a/server/tests/test_macro_tracker.py
+++ b/server/tests/test_macro_tracker.py
@@ -1,0 +1,43 @@
+import pytest
+
+from engine.MacroTracker import MacroTracker
+
+
+def test_system_panic_defaults_to_literal_panic_resource():
+    """Backward compatibility: existing scenarios never set panic_resource,
+    so the metric must keep reading the literal 'panic' key."""
+    tracker = MacroTracker()
+    portfolios = {
+        "alice": {"credits": 10.0, "panic": 0.2},
+        "bob": {"credits": 5.0, "panic": 0.6},
+    }
+
+    snap = tracker.compute(portfolios, market_engine=None, tick=1)
+
+    assert snap["system_panic"] == pytest.approx(0.4)
+
+
+def test_system_panic_reads_configured_panic_resource():
+    """A scenario in another domain (e.g. clinical/behavioral-health) can
+    point panic_resource at a differently-named bounded resource and still
+    get the system_panic aggregate under the same output key."""
+    tracker = MacroTracker(panic_resource="relapse_risk")
+    portfolios = {
+        "patient_1": {"self_efficacy": 40.0, "relapse_risk": 0.3, "panic": 0.9},
+        "patient_2": {"self_efficacy": 22.0, "relapse_risk": 0.7},
+    }
+
+    snap = tracker.compute(portfolios, market_engine=None, tick=1)
+
+    # Averages relapse_risk (0.3, 0.7) -> 0.5, and ignores the stray literal
+    # "panic" key entirely since panic_resource has been redirected.
+    assert snap["system_panic"] == pytest.approx(0.5)
+
+
+def test_system_panic_is_zero_when_no_agent_holds_the_panic_resource():
+    tracker = MacroTracker(panic_resource="relapse_risk")
+    portfolios = {"alice": {"credits": 10.0}}
+
+    snap = tracker.compute(portfolios, market_engine=None, tick=1)
+
+    assert snap["system_panic"] == 0.0


### PR DESCRIPTION
<details>

## Make the "panic" resource configurable (`global_rules.panic_resource`)

### Problem

`panic` is the only resource name hardcoded in the engine, in three spots:

- `DoxaEngine.py` — the maintenance pass reads/writes
  `portfolios[agent_id]["panic"]` literally for `panic_decay_rate` and
  `portfolio_distress_panic_rate`.
- `MacroTracker.py` — the aggregate `system_panic` metric averages the
  literal `"panic"` key across all portfolios.
- The client (`MacroPanel.tsx`) surfaces this in a dedicated panel.

Every other resource (capital, labor_units, wage_share, attention,
credibility, etc.) is fully data-driven from the YAML — only `panic`
isn't. For a non-economic scenario (in my case, relapse/recovery dynamics
for addiction-support simulation) this means either literally naming a
resource `panic` when conceptually it's `relapse_risk`, or silently
losing decay, portfolio-distress feedback, and the system-wide metric.

`info-diffusion.yaml` confirms this is already a known convention (it
keeps `panic` literal despite being a misinformation scenario), so this
PR isn't introducing a new pattern — it's generalizing one that already
exists.

### Solution

Added an optional top-level `global_rules` key:

```yaml
global_rules:
  panic_resource: relapse_risk   # default: "panic"
  relation_dynamics:
    panic_decay_rate: 0.06
    portfolio_distress_panic_rate: 0.08
```

- `SimulationEnvironment` passes `panic_resource` into `MacroTracker`'s
  constructor (default `"panic"`, so no existing scenario changes
  behavior).
- `DoxaEngine._run_maintenance` reads the same key once and uses it in
  place of the `"panic"` literal in both blocks.
- `MacroTracker.compute()` uses `self.panic_resource` instead of the
  literal; the output key stays `system_panic` always, so the API and
  frontend need zero changes.
- Docs updated in `CONFIG_YAML_REFERENCE.md` (section 1.9).
- 3 new unit tests in `test_macro_tracker.py` (default, custom name, no
  agent holding the configured resource).

### Compatibility

All 69 existing tests pass unchanged (including the smoke tests that
instantiate every scenario under `scenarios/`, goodwin-growth-cycle.yaml
included). The `"panic"` default makes this a strictly additive change.

### Why now

I'm forking Doxa for a second scenario, this time in an
addiction-support/recovery context (non-economic), where `panic` as a
literal resource name doesn't fit the agent personas. Rather than keep
the misleading name in my YAML, I preferred to generalize the one spot
where the engine assumes that name — small and targeted, not a refactor.

</details>
