### PR TITLE
issue #25 apply version input to pyproject.toml before PyPI build

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -26,6 +26,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
 
+      - name: Set package version from input
+        working-directory: server
+        run: |
+          sed -i "s/^version = .*/version = \"${{ github.event.inputs.version }}\"/" pyproject.toml
+          grep -q "^version = \"${{ github.event.inputs.version }}\"\$" pyproject.toml || \
+            { echo "::error::Failed to set version to ${{ github.event.inputs.version }} in pyproject.toml"; exit 1; }
+          grep '^version' pyproject.toml
+
       - name: Build package
         working-directory: server
         run: |


### PR DESCRIPTION
## Fix
Added a `Set package version from input` step that writes the input version into `server/pyproject.toml` before `python -m build`, with a guard that fails the job explicitly if the substitution doesn't
match (instead of silently publishing the previous version).

## Testing
No CI-safe way to test the actual PyPI publish step (relies on the
trusted publisher OIDC flow), so I validated the rest of the
pipeline locally:
- sed/grep substitution on an isolated copy of `pyproject.toml`
- guard correctly fails on a `pyproject.toml` without a static
  `version = ...` line (e.g. hypothetical future `dynamic = ["version"]`)
- full local `python -m build` with a bumped version — produced
  `doxa_ai-<version>.tar.gz` / `.whl` with correct metadata


Closes #25.